### PR TITLE
fix Websweeper.js homepage link

### DIFF
--- a/index.html
+++ b/index.html
@@ -23,7 +23,7 @@
       handleLayout();
     </script>
     <title>Websweeper</title>
-    <h1 class="siteHeader" title="Websweeper.js"><a onmouseover="this.style.textDecoration='underline'"  onmouseout="this.style.textDecoration='none'" href='/index.html'>Websweeper.js</a></h1>
+    <h1 class="siteHeader" title="Websweeper.js"><a onmouseover="this.style.textDecoration='underline'"  onmouseout="this.style.textDecoration='none'" href='/websweeper/'>Websweeper.js</a></h1>
     <h5 class="siteEdition">No Flags (NF) Local Edition</h5>
 </head>
 <body id="browserBody" style="zoom: 100%;">


### PR DESCRIPTION
When clicking on the big blue Websweeper.js site header, link dies because of how the index.html is hostsed on github.

Adjusted index.html to point to the serving root, baseurl/websweeper/

Ben